### PR TITLE
feat: zsh support - port bash-only constructs to run under zsh's ksh emulation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,25 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # bash is the historical target; zsh is the macOS default login shell.
+        # Utilities run under zsh's ksh emulation (provided by xsh).
+        shell: [bash, zsh]
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / ${{ matrix.shell }}
+    # The zsh jobs install xsh from alexzhangs/xsh master, which does not yet
+    # carry zsh support — so they stay red until that release lands. Keep them
+    # non-blocking until then. TODO: remove this once a zsh-supporting xsh is
+    # released to master, so the zsh jobs become gating.
+    continue-on-error: ${{ matrix.shell == 'zsh' }}
 
     steps:
+      - name: Install zsh (Linux)
+        if: matrix.shell == 'zsh' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
       - name: Install xsh
         run: |
           git clone --depth=50 --branch=master https://github.com/alexzhangs/xsh.git /tmp/xsh
@@ -25,9 +39,8 @@ jobs:
           source ~/.xshrc
           xsh load -b "${{ github.head_ref || github.ref_name }}" xsh-lib/core
 
-      - name: Run tests
-        shell: bash
-        run: |
-          source ~/.xshrc
-          xsh list
-          bash ~/.xsh/repo/xsh-lib/core/test.sh
+      - name: Run tests (${{ matrix.shell }})
+        # test.sh self-sources ~/.xshrc, so running it as a child of the matrix
+        # shell makes the utilities execute under that shell (bash, or zsh's
+        # ksh emulation). No need to `source ~/.xshrc` here first.
+        run: ${{ matrix.shell }} ~/.xsh/repo/xsh-lib/core/test.sh

--- a/functions/array/append.sh
+++ b/functions/array/append.sh
@@ -13,14 +13,16 @@
 #?   declare -a arr='([3]="III" [4]="IV" [5]="V" [6]="VI")'
 #?
 function append () {
-    declare __i
+    declare __i __value
 
     if [[ $# -lt 2 ]]; then
         return 255
     fi
 
     for __i in $(seq 2 $#); do
+        # `${!__i}` is bash-only; `${*:N:1}` works in both shells
+        __value=${*:$((__i)):1}
         # clear IFS to avoid triming whitespace
-        IFS='' read -r "$1[$(xsh /array/inext "$1")]" <<< "${!__i}" || return $?
+        IFS='' read -r "$1[$(xsh /array/inext "$1")]" <<< "${__value}" || return $?
     done
 }

--- a/functions/array/echo.sh
+++ b/functions/array/echo.sh
@@ -13,7 +13,5 @@
 #?   IV
 #?
 function echo () {
-    # try to declare nothing, new variable may override input variable.
-    set -- "$1[@]"
-    printf "%s\n" "${!1}"
+    eval "printf '%s\n' \"\${${1:?}[@]}\""
 }

--- a/functions/array/first.sh
+++ b/functions/array/first.sh
@@ -12,7 +12,11 @@
 #?   III
 #?
 function first () {
-    # try to declare nothing, new variable may override input variable.
-    set -- "$1[$(xsh /array/ifirst "$1")]"
-    echo "${!1}"
+    declare __ifirst
+    __ifirst=$(xsh /array/ifirst "${1:?}")
+    if [[ -z ${__ifirst} ]]; then
+        # empty array
+        return 1
+    fi
+    eval "echo \"\${${1}[${__ifirst}]}\""
 }

--- a/functions/array/ilast.sh
+++ b/functions/array/ilast.sh
@@ -15,5 +15,8 @@ function ilast () {
     # try to declare nothing, new variable may override input variable.
     # shellcheck disable=SC2046
     set -- $(xsh /array/index "$1")
-    echo "${!#}"
+    # NOTE: `${!#}` is bash-only (zsh silently expands it as `$#`), and
+    # expands to `$0` when there is no argument; `${*: -1}` works in both
+    # shells and expands to nothing when there is no argument
+    echo "${*: -1}"
 }

--- a/functions/array/index.sh
+++ b/functions/array/index.sh
@@ -12,8 +12,18 @@
 #?   3 4
 #?
 function index () {
-    # shellcheck disable=SC2125
-    # shellcheck disable=SC1083
-    declare -a __index=\(\${!$1[@]}\)  # magic indirect expansion
-    echo "${__index[@]}"
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # zsh has no `${!arr[@]}`, and zsh arrays are never sparse: the
+        # indices are always contiguous, 0 .. len-1 under the ksh emulation
+        declare __len __i __index=
+        eval "__len=\${#${1:?}[@]}"
+        for (( __i=0; __i<__len; __i++ )); do
+            __index=${__index}${__index:+ }${__i}
+        done
+        echo "${__index}"
+    else
+        declare -a __index
+        eval "__index=( \"\${!${1:?}[@]}\" )"
+        echo "${__index[@]}"
+    fi
 }

--- a/functions/array/is-array.sh
+++ b/functions/array/is-array.sh
@@ -12,5 +12,9 @@
 #?   0
 #?
 function is-array () {
-    [[ "$(declare -p "$1" 2>/dev/null || :)" =~ "declare -a" ]]
+    # bash declares arrays as `declare -a`, zsh as `typeset -a` or
+    # `typeset -g -a`; keep the regex in a variable for bash 3.2 (a quoted
+    # regex is matched literally there)
+    declare __re='^(declare|typeset) (-g )?-a'
+    [[ "$(declare -p "$1" 2>/dev/null || :)" =~ $__re ]]
 }

--- a/functions/array/last/1.sh
+++ b/functions/array/last/1.sh
@@ -12,7 +12,11 @@
 #?   IV
 #?
 function last () {
-    # try to declare nothing, new variable may override input variable.
-    set -- "$1[$(xsh /array/ilast "$1")]"
-    echo "${!1}"
+    declare __ilast
+    __ilast=$(xsh /array/ilast "${1:?}")
+    if [[ -z ${__ilast} ]]; then
+        # empty array
+        return 1
+    fi
+    eval "echo \"\${${1}[${__ilast}]}\""
 }

--- a/functions/array/last/2.sh
+++ b/functions/array/last/2.sh
@@ -12,7 +12,13 @@
 #?   IV
 #?
 function last () {
-    # try to declare nothing, new variable may override input variable.
-    set -- "$1[@]"
-    echo "${!1:(-1)}"
+    declare __len
+    eval "__len=\${#${1:?}[@]}"
+    if [[ ${__len} -eq 0 ]]; then
+        # empty array
+        return 1
+    fi
+    # NOTE: a negative offset `:(-1)` is unsupported by bash 3.2 and zsh;
+    # use the explicit offset instead
+    eval "echo \"\${${1}[@]:$((__len - 1))}\""
 }

--- a/functions/array/merge.sh
+++ b/functions/array/merge.sh
@@ -17,33 +17,69 @@
 #?   $ arr=([3]="x=III" [4]="y=IV" [5]="y=V"); @merge arr =; declare -p arr
 #?   declare -a arr='([3]="x=III" [5]="y=V")'
 #?
+#? Zsh:
+#?   Zsh arrays can't be sparse: the surviving elements are re-indexed
+#?   contiguously from 0, rather than keeping their original indices.
+#?
 function merge () {
     declare __i __j
-    declare __arr_i __arr_j
+    declare __val_i __val_j
 
     if [[ -z $1 ]]; then
         printf "ERROR: Array name is null or not set.\n" >&2
         return 255
     fi
 
-    for __i in $(xsh /array/index "$1"); do
-        __arr_i="$1[__i]"
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # zsh arrays can't be sparse: `unset 'arr[i]'` just empties the
+        # element rather than removing it. Rebuild the array without the
+        # merged-away elements instead; the surviving elements are
+        # re-indexed contiguously.
+        declare __len __survive
+        declare -a __result
+        eval "__len=\${#${1}[@]}"
+        for (( __i=0; __i<__len; __i++ )); do
+            eval "__val_i=\${${1}[${__i}]}"
+            __survive=1
+            for (( __j=__i+1; __j<__len; __j++ )); do
+                eval "__val_j=\${${1}[${__j}]}"
+                if [[ -z $2 ]]; then
+                    if [[ ${__val_i} == "${__val_j}" ]]; then
+                        __survive=0
+                        break
+                    fi
+                else
+                    if [[ ${__val_i%%"${2}"*} == "${__val_j%%"${2}"*}" ]]; then
+                        __survive=0
+                        break
+                    fi
+                fi
+            done
+            if [[ ${__survive} -eq 1 ]]; then
+                __result+=( "${__val_i}" )
+            fi
+        done
+        eval "${1}=( \"\${__result[@]}\" )"
+        return
+    fi
 
+    for __i in $(xsh /array/index "$1"); do
         for __j in $(xsh /array/index "$1"); do
             if [[ $__j -le $__i ]]; then
                 continue
             fi
 
-            __arr_j="$1[__j]"
+            eval "__val_i=\${${1}[${__i}]}"
+            eval "__val_j=\${${1}[${__j}]}"
 
             if [[ -z $2 ]]; then
-                if [[ ${!__arr_i} == "${!__arr_j}" ]]; then
-                    unset "${__arr_i}"
+                if [[ ${__val_i} == "${__val_j}" ]]; then
+                    unset "${1}[${__i}]"
                     break
                 fi
             else
-                if [[ ${!__arr_i%%"${2}"*} == "${!__arr_j%%"${2}"*}" ]]; then
-                    unset "${__arr_i}"
+                if [[ ${__val_i%%"${2}"*} == "${__val_j%%"${2}"*}" ]]; then
+                    unset "${1}[${__i}]"
                     break
                 fi
             fi

--- a/functions/array/search.sh
+++ b/functions/array/search.sh
@@ -63,11 +63,11 @@ function search () {
         return 255
     fi
 
-    declare __i __arr_i
+    declare __i __val
     for __i in $(xsh /array/index "$1"); do
-        __arr_i="$1[__i]"
+        eval "__val=\${${1}[${__i}]}"
 
         # shellcheck disable=SC2015
-        test "${!__arr_i}" "$__operand" "$2" && echo "$__i" || :
+        test "${__val}" "$__operand" "$2" && echo "$__i" || :
     done
 }

--- a/functions/date/adjust-d.sh
+++ b/functions/date/adjust-d.sh
@@ -195,9 +195,9 @@ function adjust-d () {
     function __adjust-d__ () {
         declare ts
 
-        if ! __is_adjust_opt__ "${!#}"; then
+        if ! __is_adjust_opt__ "${*: -1}"; then
             # get last argument
-            ts=${!#}
+            ts=${*: -1}
 
             # remove last argument from the argument list
             set -- "${@:1:$#-1}"
@@ -266,11 +266,11 @@ function adjust-d () {
 
         declare ts
 
-        if __is_adjust_opt__ "${!#}"; then
+        if __is_adjust_opt__ "${*: -1}"; then
             ts=$(date "${XSH_X_DATE__DATETIME_FMT:?}")
         else
             # get last argument
-            ts=${!#}
+            ts=${*: -1}
 
             # remove last argument from the argument list
             set -- "${@:1:$#-1}"

--- a/functions/date/adjust-v.sh
+++ b/functions/date/adjust-v.sh
@@ -70,7 +70,7 @@ function adjust-v () {
     #?
 
     # get the last argument
-    declare ts=${!#}
+    declare ts=${*: -1}
 
     declare opt_v_regexp='^[+-]?[0-9]{1,}[ymdwHMS]$|^[+-]{1}(Mon|Tue|Wed|Thu|Fri|Sat|Sun)$'
 

--- a/functions/date/get.sh
+++ b/functions/date/get.sh
@@ -21,15 +21,13 @@ function get () {
         declare -a fmts
 
         while getopts "${OPTION:?}" opt; do
-            # shellcheck disable=SC2254
-            case $opt in
-                $CONDITION)
-                    fmts+=( "%$opt" )
-                    ;;
-                *)
-                    return 255
-                    ;;
-            esac
+            # plain string membership: a dynamic extglob/alternation pattern
+            # would not be matched as a pattern by zsh
+            if [[ ${CONDITION:?} == *"|${opt}|"* ]]; then
+                fmts+=( "%$opt" )
+            else
+                return 255
+            fi
         done
         shift $((OPTIND - 1))
 
@@ -57,13 +55,9 @@ function get () {
     # remove the non-default options
     DEFAULT_OPTIONS=( "${DEFAULT_OPTIONS[@]#[a-zA-Z]}" )
 
-    # generate extglob condition `@(x|y)`
+    # generate the allowed-options condition `|x|y|`
     CONDITION=${list//%/}
-    CONDITION=${CONDITION// /|}
-    CONDITION="@(${CONDITION})"
-
-    # enable extglob in order to use dynamic case condition
-    shopt -s extglob
+    CONDITION="|${CONDITION// /|}|"
 
     # call the real implementation
     __get__ "${@:2}"; declare ret=$?

--- a/functions/file/inject.sh
+++ b/functions/file/inject.sh
@@ -49,6 +49,10 @@
 #? @subshell
 #?
 function inject () {
+    # zsh: build FUNCNAME from zsh's funcstack (0-indexed under the ksh
+    # emulation applied on import, so the indexes match bash's FUNCNAME)
+    # shellcheck disable=SC2034,SC2154
+    [[ -z ${ZSH_VERSION-} ]] || declare -a FUNCNAME=( "${funcstack[@]}" )
 
     declare OPTIND OPTARG opt
 

--- a/functions/file/smartpath.sh
+++ b/functions/file/smartpath.sh
@@ -28,14 +28,23 @@ function smartpath () {
     declare file=${1:?}
     declare dir=$2
 
+    declare source_file=-bash
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # zsh has no BASH_SOURCE; prompt escape %x expands to the file
+        # containing the source code currently being executed
+        eval 'source_file=${(%):-%x}'
+    else
+        source_file=${BASH_SOURCE[0]}
+    fi
+
     if xsh /file/is-abspath "${file:?}"; then
         echo "$file"
     elif [[ -n $dir && -f $dir/$file ]]; then
         xsh /file/abspath "$dir/$file"
     elif [[ -f $file ]]; then
         xsh /file/abspath "$file"
-    elif [[ ${BASH_SOURCE[0]} != -bash && -f "$(dirname "${BASH_SOURCE[0]}")/$file" ]]; then
-        xsh /file/abspath "$(dirname "${BASH_SOURCE[0]}")/$file"
+    elif [[ ${source_file} != -bash && -f "$(dirname "${source_file}")/$file" ]]; then
+        xsh /file/abspath "$(dirname "${source_file}")/$file"
     else
         xsh log error "not found: $file $dir"
         return 255

--- a/functions/ini/parser.awk
+++ b/functions/ini/parser.awk
@@ -110,6 +110,14 @@ function gen_array_variables (name, array, quote, single,   i, sep, SEP, key, KE
 #? Output:
 #?   [String]  Generated shell variables for INI file.
 #?
+BEGIN {
+    # Declare the accumulator arrays up front. Otherwise the first reference is
+    # `arr[length(arr)+1]`, where `length(arr)` makes gawk type `arr` as a
+    # scalar and then reject the array subscript ("attempt to use scalar as an
+    # array"). BSD awk (macOS) tolerates it; gawk (most Linux) does not.
+    split("", sns)
+    split("", kns)
+}
 NF>0 && !/^;/ {  # filter out empty and commented lines
     FS = "="
 

--- a/functions/int/set/rpncalc.sh
+++ b/functions/int/set/rpncalc.sh
@@ -32,10 +32,14 @@ function rpncalc () {
     while [[ $# -gt 0 ]]; do
         if __is_comparator "$1"; then
             # IS OPERATORS
-            o1=${STACK[*]:(-1)}
-            unset "STACK[$((${#STACK[@]} - 1))]"
-            o2=${STACK[*]:(-1)}
-            unset "STACK[$((${#STACK[@]} - 1))]"
+            # NOTE: a negative offset `:(-1)` is unsupported by bash 3.2 and
+            # zsh, and `unset 'STACK[i]'` doesn't remove the element under
+            # zsh: read the last element with an explicit offset and pop it
+            # by re-assigning the array instead
+            o1=${STACK[*]:$((${#STACK[@]} - 1))}
+            STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
+            o2=${STACK[*]:$((${#STACK[@]} - 1))}
+            STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
 
             STACK+=( "$(x-int-set-set "$o1" "$1" "$o2")" )
         else

--- a/functions/io/confirm.sh
+++ b/functions/io/confirm.sh
@@ -49,14 +49,19 @@ function confirm () {
         return 255
     fi
 
-    declare options=( "-p" "${message} [${positive}/${negative}]: " )
+    # `read -p PROMPT` is bash-only (zsh `read -p` reads from a coprocess):
+    # print the prompt explicitly instead
+    declare prompt="${message} [${positive}/${negative}]: "
+    declare -a options
 
     if [[ -n ${timeout} ]]; then
         options+=( "-t" "${timeout}" )
     fi
 
     declare REPLY
-    while read -r "${options[@]}" REPLY && [[ ${REPLY} != "${positive}" && ${REPLY} != "${negative}" ]]; do
+    while printf '%s' "${prompt}" >&2 \
+              && read -r "${options[@]}" REPLY \
+              && [[ ${REPLY} != "${positive}" && ${REPLY} != "${negative}" ]]; do
         :
     done
 

--- a/functions/math/infix2rpn.sh
+++ b/functions/math/infix2rpn.sh
@@ -115,18 +115,23 @@ function infix2rpn () {
         unset operand
     }
 
+    # NOTE: a negative offset `:(-1)` is unsupported by bash 3.2 and zsh:
+    # read the last element with an explicit offset instead.
+    # NOTE: `unset 'STACK[i]'` doesn't remove the element under zsh (zsh
+    # arrays can't be sparse): pop the last element by re-assigning the
+    # array with the last element sliced off instead.
     function __process_operator () {
         if [[ -n $operator ]]; then
-            while [[ ${#STACK[@]} -gt 0 && ${STACK[*]:(-1)} != '(' ]]; do
-                priority=$($COMPARATOR "$operator" "${STACK[@]:(-1)}")
+            while [[ ${#STACK[@]} -gt 0 && ${STACK[*]:$((${#STACK[@]} - 1))} != '(' ]]; do
+                priority=$($COMPARATOR "$operator" "${STACK[@]:$((${#STACK[@]} - 1))}")
                 if [[ -z $priority ]]; then
                     xsh log error "wrong operator in the expression or specified wrong comparator."
                     return 255
                 elif [[ $priority -gt 0 ]]; then
                     break
                 else
-                    OUTPUT+=( "${STACK[@]:(-1)}" )
-                    unset "STACK[$((${#STACK[@]} - 1))]"
+                    OUTPUT+=( "${STACK[@]:$((${#STACK[@]} - 1))}" )
+                    STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
                 fi
             done
             STACK+=( "$operator" )
@@ -142,9 +147,23 @@ function infix2rpn () {
 
     # Convert Infix to RPN
 
+    # `read -n1` is bash-only; zsh reads single characters with `-k1`
+    # (`-u0` keeps it reading from stdin rather than the terminal), and
+    # unlike bash it returns the newline character itself - normalize it
+    # to an empty char to match the bash behavior
+    declare -a read_char_opts
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        read_char_opts=( -k1 -u0 )
+    else
+        read_char_opts=( -n1 )
+    fi
+
     declare operand operator priority
     declare char
-    while IFS= read -r -n1 char; do
+    while IFS= read -r "${read_char_opts[@]}" char; do
+        if [[ $char == $'\n' ]]; then
+            char=''
+        fi
         case "$char" in
             # WHITESPACE or TAB
             [[:blank:]])
@@ -161,13 +180,13 @@ function infix2rpn () {
             ')')
                 __process_operand || return $?
 
-                while [[ ${STACK[*]:(-1)} != '(' ]]; do
-                    OUTPUT+=( "${STACK[@]:(-1)}" )
-                    unset "STACK[$((${#STACK[@]} - 1))]"
+                while [[ ${#STACK[@]} -gt 0 && ${STACK[*]:$((${#STACK[@]} - 1))} != '(' ]]; do
+                    OUTPUT+=( "${STACK[@]:$((${#STACK[@]} - 1))}" )
+                    STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
                 done
 
-                if [[ ${STACK[*]:(-1)} == '(' ]]; then
-                    unset "STACK[$((${#STACK[@]} - 1))]"
+                if [[ ${#STACK[@]} -gt 0 && ${STACK[*]:$((${#STACK[@]} - 1))} == '(' ]]; then
+                    STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
                 else
                     xsh log error "wrong expression found! a right parenthesis ')' without a paired left parentthesis '('."
                     return 255
@@ -189,8 +208,8 @@ function infix2rpn () {
     done <<< "${*//$'\n'/ }"  # Replace newline as whitespace
 
     while [[ ${#STACK[@]} -gt 0 ]]; do
-        OUTPUT+=( "${STACK[@]:(-1)}" )
-        unset "STACK[$((${#STACK[@]} - 1))]"
+        OUTPUT+=( "${STACK[@]:$((${#STACK[@]} - 1))}" )
+        STACK=( "${STACK[@]:0:$((${#STACK[@]} - 1))}" )
     done
 
     unset -f __process_operand __process_operator

--- a/functions/string/append.sh
+++ b/functions/string/append.sh
@@ -16,5 +16,7 @@
 #?   0-1-2-3-4-5-6-7-8-9-10
 #?
 function append () {
-    read -r "$1" <<< "${!1}${IFS:0:1}${*:2}"
+    # `${!1}` is bash-only; `${*:2}` joins the values with the first
+    # character of $IFS in both shells
+    eval "${1:?}=\${${1}}\${IFS:0:1}\${*:2}"
 }

--- a/functions/string/copy.sh
+++ b/functions/string/copy.sh
@@ -20,5 +20,7 @@ function copy () {
     else
         unset "$2"  # in case $2 is Array
     fi
-    read -r "$2" <<< "${!1}"
+    # `${!1}` is bash-only; the eval also preserves multiline values that
+    # `read <<<` would truncate at the first newline
+    eval "${2:?}=\${${1:?}}"
 }

--- a/functions/string/pop.sh
+++ b/functions/string/pop.sh
@@ -16,7 +16,8 @@
 #?
 function pop () {
     declare __popping_from_variable_name
-    declare __popping_value=${!1}
+    declare __popping_value
+    eval "__popping_value=\${${1:?}}"
 
     __popping_from_variable_name=$(declare \
               | grep -E -o "^[_]*$1[_]*" \

--- a/functions/trap/err.sh
+++ b/functions/trap/err.sh
@@ -44,7 +44,10 @@ function err () {
     while getopts Eer opt; do
         case $opt in
             E)
-                set -E
+                # zsh: traps are inherited by shell functions by default
+                if [[ -z ${ZSH_VERSION-} ]]; then
+                    set -E
+                fi
                 ;;
             e)
                 on_error='exit'
@@ -65,6 +68,9 @@ function err () {
     # shellcheck disable=SC2016
     funcode='
         function __xsh_trap_err_on_err__ () {
+            # zsh: pin bash-compatible (0-indexed) arrays and word splitting
+            [[ -z ${ZSH_VERSION-} ]] || emulate -L ksh
+
             declare ret=$1
             declare command=$2
             declare lineno=$3
@@ -73,7 +79,10 @@ function err () {
             declare source=("${@:6}")
 
             declare max_index
-            max_index=$(printf "%s\n" ${!func[@]} ${!source[@]} | sort -rn | head -1)
+            max_index=$(( (${#func[@]} > ${#source[@]} ? ${#func[@]} : ${#source[@]}) - 1 ))
+            if [[ $max_index -lt 0 ]]; then
+                max_index=
+            fi
 
             printf "\nError code: %s\n" "$ret"
             printf "Traceback (most recent call first)\n"
@@ -103,7 +112,20 @@ function err () {
     fi
 
     # set trap ERR
-    trap '__xsh_trap_err_on_err__ $? \
-         "${BASH_COMMAND}" "${LINENO}" "${FUNCNAME[*]}" "$0" "${BASH_SOURCE[@]}" 1>&2; \
-         '$on_error ERR
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # LOCAL_TRAPS (set by the ksh emulation applied on import) would
+        # remove the trap when this function returns - disable it so the
+        # trap persists, matching the bash behavior (see Clean section)
+        setopt no_local_traps
+        # zsh has no BASH_COMMAND and no useful LINENO in the trap; pass
+        # funcfiletrace (file:line of each call site) in place of BASH_SOURCE
+        # shellcheck disable=SC2154
+        trap '__xsh_trap_err_on_err__ $? \
+             "?" "?" "${funcstack[*]}" "$0" "${funcfiletrace[@]}" 1>&2; \
+             '$on_error ERR
+    else
+        trap '__xsh_trap_err_on_err__ $? \
+             "${BASH_COMMAND}" "${LINENO}" "${FUNCNAME[*]}" "$0" "${BASH_SOURCE[@]}" 1>&2; \
+             '$on_error ERR
+    fi
 }

--- a/functions/trap/get.sh
+++ b/functions/trap/get.sh
@@ -10,6 +10,12 @@
 #? Options:
 #?   [-e]      Output the entire trap expression rather than the command.
 #?
+#? Zsh:
+#?   Zsh resets traps in subshells, including command substitution: calling
+#?   this util as `$(xsh /trap/get SIGNAL)` always reports no trap. Call it
+#?   in the current shell, e.g. redirect the output to a file, instead.
+#?   Multiline trap commands are output as a single line, quoted with $'...'.
+#?
 function get () {
     declare OPTIND OPTARG opt
     declare expr=0
@@ -27,15 +33,37 @@ function get () {
     shift $((OPTIND - 1))
 
     declare str
-    str=$(trap -p "${1:?}")
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # zsh resets traps in subshells: `$(trap ...)` always sees none, and
+        # zsh's trap builtin has no `-p`. List the traps into a temp file in
+        # the current shell and filter by the signal name instead.
+        # NOTE: zsh lists each trap as a single line, quoting multiline
+        # commands with $'...'.
+        declare tmpfile=/tmp/xsh-trap-get-$$-$RANDOM
+        trap > "$tmpfile"
+        str=$(grep " ${1:?}\$" "$tmpfile" || :)
+        /bin/rm -f "$tmpfile"
+    else
+        str=$(trap -p "${1:?}")
+    fi
 
     if [[ -z $str && $expr -eq 0 ]]; then
         str=-
     elif [[ -z $str && $expr -eq 1 ]]; then
         str="trap - ${1:?}"
     elif [[ -n $str && $expr -eq 0 ]]; then
-        str=${str#trap -- \'}
-        str=${str%\' *}
+        str=${str#trap -- }
+        str=${str% *}
+        case $str in
+            \$\'*)
+                str=${str#\$\'}
+                str=${str%\'}
+                ;;
+            \'*)
+                str=${str#\'}
+                str=${str%\'}
+                ;;
+        esac
     fi
 
     printf '%s\n' "$str"

--- a/functions/trap/return.sh
+++ b/functions/trap/return.sh
@@ -20,6 +20,11 @@
 #?                For current returned function, following info is available inside
 #?                the COMMAND:
 #?                  * Return code:   available as `$1`.
+#?                    NOTE: bash doesn't expose the argument of an explicit
+#?                    `return N` to the RETURN trap: under bash `$1` is the
+#?                    status of the last command executed before the return
+#?                    (they are the same when the function returns implicitly).
+#?                    Under zsh `$1` is the actual return code.
 #?                  * Function name: available as `${FUNCNAME[1]}'.
 #?
 #? Return:
@@ -52,6 +57,19 @@
 #?     * variable __XSH_TRAP_RETURN_CLEAN_FLAG
 #?     * function __xsh_trap_return_bypass__ ()
 #?     * function __xsh_trap_return_on_return__ ()
+#?
+#? Zsh:
+#?   Zsh has no RETURN trap. Under zsh this util emulates it with a cascade of
+#?   function-scoped EXIT traps (NO_POSIX_TRAPS): an EXIT trap set inside a
+#?   function fires on that function's return, and the trap command re-arms
+#?   the trap in the caller's scope, walking up the calling chain like the
+#?   bash RETURN trap does.
+#?   Differences from the bash behavior:
+#?     * The trap fires only on the returns of the upstream calling chain
+#?       captured at registering time, not on the returns of functions called
+#?       afterwards (with `-fF NAME` the net effect is the same).
+#?     * The cascade always stops at the top level, the trap never outlives
+#?       the calling chain.
 #?
 function return () {
 
@@ -91,6 +109,140 @@ function return () {
         esac
     done
     shift $((OPTIND - 1))
+
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        if [[ -z $1 ]]; then
+            xsh log error "parameter COMMAND null or not set."
+            return 255
+        fi
+
+        if [[ $append -eq 1 && -n ${__XSH_TRAP_RETURN_COMMAND-} ]]; then
+            # the armed trap reads the command from the global at firing time
+            typeset -g __XSH_TRAP_RETURN_COMMAND=${__XSH_TRAP_RETURN_COMMAND}$'\n'$1
+            return 0
+        fi
+
+        typeset -g __XSH_TRAP_RETURN_COMMAND=$1
+        typeset -g __XSH_TRAP_RETURN_FIRE_ONCE=$fire_once
+        typeset -g __XSH_TRAP_RETURN_FIRE_ON_LAST=$fire_on_last
+        typeset -g __XSH_TRAP_RETURN_FIRE_ON_NAME=$fire_on_name
+
+        # the name of the function whose return fires the trap the next time;
+        # starts with this function itself, whose return is always skipped
+        set -- "${funcstack[@]}"
+        typeset -g __XSH_TRAP_RETURN_FUNCNAME=$1
+        typeset -g __XSH_TRAP_RETURN_REGISTER_FUNCNAME=$1
+
+        #? Description:
+        #?   Evaluate the firing and cleaning logic on each return of the
+        #?   functions in the calling chain.
+        #?   Called from the cascading EXIT trap: at that point the returned
+        #?   function is already popped off `funcstack`, and the current
+        #?   scope is the function the trap will be re-armed in.
+        #?
+        #? Usage:
+        #?   __xsh_trap_return_on_exit__ <RETURN_CODE>
+        #?
+        # shellcheck disable=SC2329  # invoked indirectly by the trap command
+        function __xsh_trap_return_on_exit__ () {
+            # pin bash-compatible (0-indexed) arrays and word splitting for
+            # the eval of the trapped COMMAND
+            emulate -L ksh
+
+            declare __rc=$1
+
+            # the name of the function that just returned
+            declare __returning=${__XSH_TRAP_RETURN_FUNCNAME-}
+
+            # the remaining calling chain: funcstack minus this function
+            set -- "${funcstack[@]}"
+            shift
+            declare __chain_len=$#
+
+            # remember the name for the next firing
+            typeset -g __XSH_TRAP_RETURN_FUNCNAME=${1-}
+
+            declare __fire_once=${__XSH_TRAP_RETURN_FIRE_ONCE:-0}
+            declare __fire_on_last=${__XSH_TRAP_RETURN_FIRE_ON_LAST:-0}
+            declare __fire_on_name=${__XSH_TRAP_RETURN_FIRE_ON_NAME-}
+
+            typeset -g __XSH_TRAP_RETURN_CLEAN_FLAG=0
+
+            # skip the return of the registering function
+            if [[ $__returning != "${__XSH_TRAP_RETURN_REGISTER_FUNCNAME-}" ]]; then
+                # count the occurrences of the fireable name in the chain
+                declare __count=0 __name
+                if [[ -n $__fire_on_name ]]; then
+                    for __name in "$@"; do
+                        if [[ $__name == "$__fire_on_name" ]]; then
+                            __count=$((__count + 1))
+                        fi
+                    done
+                fi
+
+                # firing logic: the returned function is already off the
+                # chain, so `last return of NAME` means: the returned
+                # function is NAME and NAME is not in the remaining chain
+                if [[ -z $__fire_on_name \
+                          || ( $__returning == "$__fire_on_name" \
+                                   && ( $__fire_on_last -eq 0 || $__count -eq 0 ) ) ]]; then
+
+                    # clean logic
+                    if [[ $__fire_once -eq 1 \
+                              || $__chain_len -eq 0 \
+                              || ( -n $__fire_on_name \
+                                       && $__returning == "$__fire_on_name" \
+                                       && $__count -eq 0 ) ]]; then
+                        typeset -g __XSH_TRAP_RETURN_CLEAN_FLAG=1
+                    fi
+
+                    # make the documented context available to COMMAND:
+                    # $1 as the return code, ${FUNCNAME[1]} as the function name
+                    # shellcheck disable=SC2034
+                    declare -a FUNCNAME=( "${0}" "$__returning" "$@" )
+                    set -- "$__rc"
+
+                    { # command begins
+                        eval "${__XSH_TRAP_RETURN_COMMAND}"
+                    } # command ends
+                fi
+            fi
+
+            # the cascade can't be re-armed at the top level
+            if [[ $__chain_len -eq 0 ]]; then
+                typeset -g __XSH_TRAP_RETURN_CLEAN_FLAG=1
+            fi
+
+            # do not need to explicitly return the former return code, trap would handle this
+        }
+
+        # the cascading trap command: evaluate the firing logic, then either
+        # re-arm the trap in the current (caller's) scope or clean up.
+        # NOTE: the `trap` builtin must be executed directly in the trap
+        # command, not inside a function, for the new trap to be scoped to
+        # the function the cascade has unwound to.
+        # shellcheck disable=SC2016  # the expansions belong to firing time
+        typeset -g __XSH_TRAP_RETURN_TRAP='__xsh_trap_return_on_exit__ "$?" 1>&2
+            if [[ ${__XSH_TRAP_RETURN_CLEAN_FLAG-} -eq 1 ]]; then
+                unset __XSH_TRAP_RETURN_CLEAN_FLAG __XSH_TRAP_RETURN_COMMAND \
+                      __XSH_TRAP_RETURN_FIRE_ONCE __XSH_TRAP_RETURN_FIRE_ON_LAST \
+                      __XSH_TRAP_RETURN_FIRE_ON_NAME __XSH_TRAP_RETURN_FUNCNAME \
+                      __XSH_TRAP_RETURN_REGISTER_FUNCNAME __XSH_TRAP_RETURN_TRAP
+                unset -f __xsh_trap_return_on_exit__
+            else
+                setopt no_posix_traps
+                trap "${__XSH_TRAP_RETURN_TRAP}" EXIT
+            fi'
+
+        # arm the trap on this function: with NO_POSIX_TRAPS it fires when
+        # this function returns, and the cascade takes over from there.
+        # `emulate -L ksh` (applied on import) makes the setopt local.
+        setopt no_posix_traps
+        # shellcheck disable=SC2064  # the value is the static trap script
+        trap "${__XSH_TRAP_RETURN_TRAP}" EXIT
+
+        return 0
+    fi
 
     # generate function code
 
@@ -176,8 +328,10 @@ function return () {
         fi
 
         # set trap RETURN
+        # `$?` passes the return code of the trapped function to the
+        # generated function, where it is available to COMMAND as `$1`
         # shellcheck disable=SC2154
-        trap '__xsh_trap_return_on_return__ 1>&2; [[ $__XSH_TRAP_RETURN_CLEAN_FLAG -eq 1 ]] && trap - RETURN || :; __xsh_trap_return_bypass__' RETURN
+        trap '__xsh_trap_return_on_return__ "$?" 1>&2; [[ $__XSH_TRAP_RETURN_CLEAN_FLAG -eq 1 ]] && trap - RETURN || :; __xsh_trap_return_bypass__' RETURN
     else
         xsh log error "parameter COMMAND null or not set."
         return 255

--- a/functions/uri/parser.sh
+++ b/functions/uri/parser.sh
@@ -71,8 +71,13 @@
 #?   * https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
 #?
 function parser () {
-    # get the last argument
-    declare uri=${!#}
+    # zsh: make `=~` populate BASH_REMATCH like bash does (the setopt is
+    # scoped by the ksh emulation applied on import)
+    # shellcheck disable=SC3044
+    [[ -z ${ZSH_VERSION-} ]] || setopt bash_rematch
+
+    # get the last argument (`${!#}` is bash-only)
+    declare uri=${*: -1}
 
     #? Following regex is based on https://stackoverflow.com/a/45977232 by Patryk Obara.
     #? Extended to support new schemes, such as: file, mailto, news, tel and urn.

--- a/functions/util/getopts/extra.sh
+++ b/functions/util/getopts/extra.sh
@@ -1,6 +1,6 @@
 #? Description:
 #?   Let you be able to use `getopts` in this way: `./script -x foo bar -y baz`
-#?   It will set an array OPTARG=(for bar) for the option `-x`.
+#?   It will set an array OPTARGS=(foo bar) for the option `-x`.
 #?   This works only within the `getopts` context.
 #?   This util must be import first before to use. Because the function `xsh`
 #?   will break the OPTIND and OPTARG variables.
@@ -13,11 +13,24 @@
 #?   while getopts x:y: opt; do
 #?     case $opt in
 #?       x)
-#?         x-util-getopts-extra "$@"; x=( "${OPTARG[@]}" );;
+#?         x-util-getopts-extra "$@"; x=( "${OPTARGS[@]}" );;
 #?       y)
 #?         y=$OPTARG;;
 #?     esac
 #?   done
+#?
+#? Bash:
+#?   For backward compatibility, under bash the array is additionally set
+#?   into OPTARG: x=( "${OPTARG[@]}" ).
+#?
+#? Zsh:
+#?   Under zsh OPTARG is a special scalar that can never hold an array
+#?   value: only OPTARGS is set.
+#?
+#?   IMPORTANT: under zsh the calling function must run under ksh emulation
+#?   (`emulate -L ksh`) - functions imported by xsh do automatically. In a
+#?   native zsh function the write to OPTIND restarts the caller's getopts
+#?   parsing from scratch, looping forever.
 #?
 function extra () {
     if [[ -z ${OPTIND} ]]; then
@@ -25,11 +38,27 @@ function extra () {
         return 255
     fi
 
-    declare i=1
+    declare -a __extra__
+    declare __next__
     # if the next argument is not an option, then append it to array OPTARG
-    while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
-        OPTARG[i]=${!OPTIND}
-        ((i++))
+    while [[ ${OPTIND} -le $# ]]; do
+        # `${!OPTIND}` is bash-only; `${*:N:1}` works in both shells
+        __next__=${*:$((OPTIND)):1}
+        if [[ ${__next__:0:1} == '-' ]]; then
+            break
+        fi
+        __extra__+=( "${__next__}" )
         ((OPTIND++))
     done
+
+    # the portable result: OPTARGS holds all the values of the option
+    # shellcheck disable=SC2034
+    OPTARGS=( "${OPTARG[@]}" "${__extra__[@]}" )
+
+    if [[ -z ${ZSH_VERSION-} ]]; then
+        # bash only: keep the original behavior, the array OPTARG.
+        # zsh: OPTARG is a special scalar that can never hold an array
+        # value (even via `unset`, the special is re-exposed); use OPTARGS.
+        OPTARG=( "${OPTARG[@]}" "${__extra__[@]}" )
+    fi
 }

--- a/test.sh
+++ b/test.sh
@@ -1,13 +1,34 @@
 #!/bin/bash
 
+# Make the `xsh` function available when this script is run as a child process.
+# Under bash, xsh and the imported utilities are exported functions, so a child
+# `bash test.sh` inherits them and this is a no-op. zsh cannot export functions,
+# so a child `zsh test.sh` would otherwise only see the `bin/xsh` shim (which
+# runs bash) — sourcing ~/.xshrc here defines xsh as a real zsh function so the
+# utilities execute under zsh's ksh emulation, which is the whole point of
+# testing under zsh.
+if ! type xsh 2>/dev/null | grep -q 'function'; then
+    # shellcheck source=/dev/null
+    . ~/.xshrc
+fi
+
 set -e -o pipefail
 
 xsh log info 'xsh list /'
 xsh list /
 
 xsh log info "/array/first"
+# Contiguous arrays behave identically in bash and zsh.
 # shellcheck disable=SC2034
-[[ $(arr=([3]="III" [4]="IV"); xsh /array/first arr) == III ]]
+[[ $(arr=(III IV); xsh /array/first arr) == III ]]
+# Sparse-array literal: bash-only. zsh arrays can't be sparse — an
+# `arr=([3]=III [4]=IV)` literal fills indices 0..2 with empty strings, so the
+# first element is "" there (a documented, inherent zsh divergence). Assert the
+# sparse behavior under bash only.
+if [[ -z ${ZSH_VERSION-} ]]; then
+    # shellcheck disable=SC2034
+    [[ $(arr=([3]="III" [4]="IV"); xsh /array/first arr) == III ]]
+fi
 
 xsh log info "/file/mask"
 [[ $(xsh /file/mask -f2 -c1-4 <<< "username password") == "username ****word" ]]


### PR DESCRIPTION
## Summary

xsh ([feature/zsh-support, alexzhangs/xsh#32](https://github.com/alexzhangs/xsh/pull/32)) runs imported utilities under zsh with `emulate -L ksh`, which covers most bashisms — but utilities depending on truly bash-only features still broke. This PR ports all of them.

### The headline: `x/trap/return` (and `x/file/inject` on top of it)

zsh has no RETURN trap (`trap ... RETURN` → `undefined signal: RETURN`, which made `x/file/inject` silently fail). The zsh port emulates it with a **cascade of function-scoped EXIT traps** (`NO_POSIX_TRAPS`): the trap command re-arms the trap from within the trap string itself, which executes in the caller's scope after each return — walking up the calling chain exactly like bash's RETURN trap unwinds. Differences (documented in the util): the cascade only follows the chain captured at registration, and always dies at the top level.

### The rest

| Utility | bash-only construct | Fix |
|---|---|---|
| trap/err | ERR trap removed on return by LOCAL_TRAPS; BASH_COMMAND/BASH_SOURCE; `${!arr[@]}` | `setopt no_local_traps`; funcstack/funcfiletrace; arithmetic max |
| trap/get | `$(trap -p SIG)` (zsh resets traps in subshells, no `-p`) | `trap > tmpfile` in the current shell + filter |
| file/inject | `${FUNCNAME[0]}` | funcstack shim |
| file/smartpath | `BASH_SOURCE` | `${(%):-%x}` under zsh |
| array/*, string/copy·append·pop, date/adjust-d·-v, uri/parser | `${!var}` indirection — **zsh silently expands `${!#}` as `$#`** | eval-based access, `${*: -1}`, `${*:N:1}` |
| array/index | `${!arr[@]}` | zsh branch: indices are always `0..len-1` (zsh arrays are never sparse) |
| array/merge | `unset 'arr[i]'` only empties the element under zsh | zsh branch rebuilds the array (re-indexed; documented) |
| array/last, math/infix2rpn, int/set/rpncalc | negative offset `:(-1)` — broken in **bash 3.2 too** — and `unset`-as-pop | explicit offset + pop by slice re-assignment |
| uri/parser | BASH_REMATCH | `setopt bash_rematch` |
| date/get | dynamic extglob `case` (zsh never glob-matches patterns from variables) + `shopt -s extglob` global leak | plain string membership, no shopt |
| util/getopts/extra | `OPTARG[i]=` (zsh OPTARG is a special scalar that can never hold an array) | portable `OPTARGS` array in both shells; bash keeps legacy OPTARG array; caller must be ksh-emulated under zsh (documented) |
| io/confirm | `read -p` | explicit prompt printf |
| math/infix2rpn | `read -n1` | `read -k1 -u0` + newline normalization under zsh |
| array/is-array | `declare -p` output parsing | matches `typeset (-g )?-a` too |

## Verification

- 51-case functional suite (sandboxed `HOME`, xsh feature/zsh-support): **51/51 under zsh 5.9 and 51/51 under macOS bash 3.2.57**, covering inject/trap-return cascade semantics (rc preservation, fire-once, self-clean), every array/string util, parsers, date, io, getopts-extra.
- Repo's own `test.sh`: green under bash (exit 0) — no regressions, including the sparse-array cases.
- The previously-skipped `call /file/inject` spec example in alexzhangs/xsh now passes under both shells against this branch (re-enabled in alexzhangs/xsh@06eb30f).

Note: the alexzhangs/xsh spec loads the latest **stable tag** of this lib, so the re-enabled example needs a release after 0.5.0 to go green in that repo's zsh CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
