### PR TITLE
fix(csv/parser): pre-type fns array so gawk doesn't empty the parse on Linux

### DIFF
--- a/functions/csv/parser.awk
+++ b/functions/csv/parser.awk
@@ -116,6 +116,11 @@ function output_table (array, m, n, ofs,   i, j) {
 #?
 function output_variable (array, m, n, prefix, quote, single,   i, j, fn, fns, fv) {
     i = 1
+    # Pre-type `fns` as an array. Under gawk the first reference `length(fns)` in
+    # `fns[length(fns)+1]` below otherwise types it as a scalar, then the subscript
+    # fails with "attempt to use scalar as an array" (BSD awk on macOS tolerates
+    # it). This empties the parse on Linux — see xsh-lib/xsql query failures.
+    split("", fns)
     for (j=1;j<=n;j++) {
         fv = array[i "," j]
         fn = get_var_name(fv)

--- a/test.sh
+++ b/test.sh
@@ -60,6 +60,18 @@ xsh log info "/json/parser"
 xsh log info "/uri/parser"
 [[ $(xsh /uri/parser -s https://github.com) == https ]]
 
+# /csv/parser -e exercises output_variable(), which builds `fns[length(fns)+1]`.
+# Under gawk (Linux) that typed `fns` as a scalar and emptied the parse; this
+# asserts the variable output is populated on every shell/OS.
+xsh log info "/csv/parser (-e variable output)"
+__csv_tmp=$(mktemp "${TMPDIR:-/tmp}/xsh-csv-test.XXXXXXXX")
+printf 'name,age\nalice,30\nbob,25\n' > "$__csv_tmp"
+__csv_out=$(xsh /csv/parser -e "$__csv_tmp")
+rm -f "$__csv_tmp"
+[[ $__csv_out == *"FIELDS_name_ROWS"* ]]
+[[ $__csv_out == *alice* ]]
+[[ $__csv_out == *bob* ]]
+
 # ---------- dotfile ----------
 # Tests use a temporary repo with a .dotfilemap to avoid depending on any
 # real dotfile repository.


### PR DESCRIPTION
csv/parser.awk's `output_variable()` built `fns[length(fns)+1]`; under gawk the first `length(fns)` typed `fns` scalar → empty `-e` output on Linux (BSD awk tolerated it). Add `split("", fns)` (same fix as ini/parser), plus a `/csv/parser -e` regression test. Surfaced by xsh-lib/xsql query tests failing on every Linux job.